### PR TITLE
Discussion: Auth changes

### DIFF
--- a/api.py
+++ b/api.py
@@ -1,17 +1,3 @@
-#!/usr/bin/env python
-#
-# @author:  Gunnar Schaefer, Kevin S. Hahn
-
-import logging
-logging.basicConfig(
-        format='%(asctime)s %(name)16.16s:%(levelname)4.4s %(message)s',
-        datefmt='%Y-%m-%d %H:%M:%S',
-        level=logging.DEBUG,
-        )
-log = logging.getLogger('scitran.api')
-logging.getLogger('scitran.data').setLevel(logging.WARNING) # silence scitran.data logging
-logging.getLogger('MARKDOWN').setLevel(logging.WARNING) # silence Markdown library logging
-
 import os
 import json
 import webapp2
@@ -109,53 +95,3 @@ def dispatcher(router, request, response):
 
 app = webapp2.WSGIApplication(routes)
 app.router.set_dispatcher(dispatcher)
-
-
-if __name__ == '__main__':
-    import pymongo
-    import argparse
-    import paste.httpserver
-
-    arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument('--host', default='127.0.0.1', help='IP address to bind to [127.0.0.1]')
-    arg_parser.add_argument('--port', default='8080', help='TCP port to listen on [8080]')
-    arg_parser.add_argument('--db_uri', help='SciTran DB URI', default='mongodb://localhost/scitran')
-    arg_parser.add_argument('--data_path', help='path to storage area', required=True)
-    arg_parser.add_argument('--apps_path', help='path to apps storage')
-    arg_parser.add_argument('--log_level', help='log level [info]', default='info')
-    arg_parser.add_argument('--ssl_cert', help='path to SSL certificate file, containing private key and certificate chain', required=True)
-    arg_parser.add_argument('--site_id', help='site ID for Scitran Central [local]', default='local')
-    arg_parser.add_argument('--oauth2_id_endpoint', help='OAuth2 provider ID endpoint', default='https://www.googleapis.com/plus/v1/people/me/openIdConnect')
-    arg_parser.add_argument('--demo', help='enable automatic user creation', action='store_true', default=False)
-    arg_parser.add_argument('--insecure', help='allow user info as urlencoded param', action='store_true', default=False)
-    args = arg_parser.parse_args()
-
-    args.quarantine_path = os.path.join(args.data_path, 'quarantine')
-    args.upload_path = os.path.join(args.data_path, 'upload')
-    app.config = vars(args)
-
-    logging.getLogger('paste.httpserver').setLevel(logging.WARNING) # silence paste logging
-    log.setLevel(getattr(logging, args.log_level.upper()))
-
-    if not app.config['ssl_cert']:
-        log.warning('SSL certificate not specified -> SciTran Central functionality disabled')
-    if app.config['site_id'] == 'local':
-        log.warning('site_id not configured -> SciTran Central functionality disabled')
-
-    if not os.path.exists(app.config['data_path']):
-        os.makedirs(app.config['data_path'])
-    if not os.path.exists(app.config['quarantine_path']):
-        os.makedirs(app.config['quarantine_path'])
-    if not os.path.exists(app.config['upload_path']):
-        os.makedirs(app.config['upload_path'])
-    if not app.config['apps_path']:
-        log.warning('apps_path is not defined -> apps functionality disabled')
-    elif not os.path.exists(app.config['apps_path']):
-        os.makedirs(app.config['apps_path'])
-
-    db_client = pymongo.MongoReplicaSetClient(args.db_uri) if 'replicaSet' in args.db_uri else pymongo.MongoClient(args.db_uri)
-    app.db = db_client.get_default_database()
-    app.db.sites.update({'_id': args.site_id}, {'_id': args.site_id, 'name': 'Local'}, upsert=True)
-
-    app.debug = True # send stack trace for uncaught exceptions to client
-    paste.httpserver.serve(app, host=args.host, port=args.port, ssl_pem=args.ssl_cert)

--- a/api.wsgi
+++ b/api.wsgi
@@ -1,22 +1,26 @@
-# @author:  Gunnar Schaefer, Kevin S. Hahn
+import logging
+logging.basicConfig(
+        format='%(asctime)s %(name)16.16s:%(levelname)4.4s %(message)s',
+        datefmt='%Y-%m-%d %H:%M:%S',
+        level=logging.DEBUG,
+        )
+log = logging.getLogger('scitran.api')
+logging.getLogger('scitran.data').setLevel(logging.WARNING) # silence scitran.data logging
 
 import os
-import re
 import time
-import logging
 import pymongo
 import argparse
-import datetime
-import uwsgidecorators
 
 import api
 import centralclient
+
 
 os.environ['PYTHON_EGG_CACHE'] = '/tmp/python_egg_cache'
 os.umask(0o022)
 
 ap = argparse.ArgumentParser()
-ap.add_argument('--db_uri', help='SciTran DB URI', required=True)
+ap.add_argument('--db_uri', help='SciTran DB URI', default='mongodb://localhost/scitran')
 ap.add_argument('--data_path', help='path to storage area', required=True)
 ap.add_argument('--apps_path', help='path to apps storage')
 ap.add_argument('--ssl_cert', help='path to SSL certificate file, containing private key and certificate chain', required=True)
@@ -24,88 +28,96 @@ ap.add_argument('--api_uri', help='api uri, with https:// prefix')
 ap.add_argument('--site_id', help='site ID for Scitran Central [local]', default='local')
 ap.add_argument('--site_name', help='site name', nargs='*', default=['Local'])  # hack for uwsgi --pyargv
 ap.add_argument('--oauth2_id_endpoint', help='OAuth2 provider ID endpoint', default='https://www.googleapis.com/plus/v1/people/me/openIdConnect')
-ap.add_argument('--demo', help='enable automatic user creation', action='store_true', default=False)
 ap.add_argument('--insecure', help='allow user info as urlencoded param', action='store_true', default=False)
 ap.add_argument('--central_uri', help='scitran central api', default='https://sdmc.scitran.io/api')
 ap.add_argument('--log_level', help='log level [info]', default='info')
-ap.add_argument('--secret', help='Shared secret', required=True)
-args = ap.parse_args()
+ap.add_argument('--drone_secret', help='shared drone secret')
 
-# HACK to allow setting the --site_name in the same way as api.py
-# --site_name 'Example Site' or --site_name "Example Site"
+if __name__ == '__main__':
+    import paste.httpserver
+    logging.getLogger('paste.httpserver').setLevel(logging.WARNING) # silence paste logging
+
+    ap.add_argument('--host', default='127.0.0.1', help='IP address to bind to [127.0.0.1]')
+    ap.add_argument('--port', default='8080', help='TCP port to listen on [8080]')
+
+args = ap.parse_args()
+log.setLevel(getattr(logging, args.log_level.upper()))
+
+# uwsgi-related HACK to allow --site_name 'Example Site' or --site_name "Example Site"
 args.site_name = ' '.join(args.site_name).strip('"\'')
+
 args.quarantine_path = os.path.join(args.data_path, 'quarantine')
 args.upload_path = os.path.join(args.data_path, 'upload')
 
-logging.basicConfig(level=getattr(logging, args.log_level.upper())) #FIXME probably not necessary, because done in api.py
-log = logging.getLogger('scitran')
+api.app.config = vars(args)
 
-# configure uwsgi application
-application = api.app
-application.config = vars(args)
+centralclient_enabled = True
+if not api.app.config['ssl_cert']:
+    centralclient_enabled = False
+    log.warning('ssl_cert not configured -> SciTran Central functionality disabled')
+if api.app.config['site_id'] == 'local':
+    centralclient_enabled = False
+    log.warning('site_id not configured -> SciTran Central functionality disabled')
+elif not api.app.config['api_uri']:
+    centralclient_enabled = False
+    log.warning('api_uri not configured -> SciTran Central functionality disabled')
+if not api.app.config['central_uri']:
+    centralclient_enabled = False
+    log.warning('central_uri not configured -> SciTran Central functionality disabled')
+if not api.app.config['drone_secret']:
+    log.warning('drone_secret not configured -> Drone functionality disabled')
+if not api.app.config['apps_path']:
+    log.warning('apps_path is not defined -> App functionality disabled')
+elif not os.path.exists(api.app.config['apps_path']):
+    os.makedirs(api.app.config['apps_path'])
+if not os.path.exists(api.app.config['data_path']):
+    os.makedirs(api.app.config['data_path'])
+if not os.path.exists(api.app.config['quarantine_path']):
+    os.makedirs(api.app.config['quarantine_path'])
+if not os.path.exists(api.app.config['upload_path']):
+    os.makedirs(api.app.config['upload_path'])
 
-application.secret = args.secret
-
-if not os.path.exists(application.config['data_path']):
-    os.makedirs(application.config['data_path'])
-if not os.path.exists(application.config['quarantine_path']):
-    os.makedirs(application.config['quarantine_path'])
-if not os.path.exists(application.config['upload_path']):
-    os.makedirs(application.config['upload_path'])
-if not application.config['apps_path']:
-    log.warning('apps_path is not defined.  Apps functionality disabled')
-else:
-    if not os.path.exists(application.config['apps_path']):
-        os.makedirs(application.config['apps_path'])
-
-# connect to db
-application.db = None
-for x in range(0, 30):
+for x in range(10):
     try:
-        db_client = pymongo.MongoReplicaSetClient(args.db_uri) if 'replicaSet' in args.db_uri else pymongo.MongoClient(args.db_uri)
-        application.db = db_client.get_default_database()
+        api.app.db = pymongo.MongoClient(args.db_uri).get_default_database()
     except:
-        time.sleep(1)
-        pass
+        time.sleep(6)
     else:
         break
 else:
     raise Exception('Could not connect to MongoDB')
 
-# TODO: make api_uri a required arg?
-application.db.sites.update({'_id': args.site_id}, {'_id': args.site_id, 'name': args.site_name, 'api_uri': args.api_uri}, upsert=True)
+api.app.db.sites.update({'_id': args.site_id}, {'_id': args.site_id, 'name': args.site_name, 'api_uri': args.api_uri}, upsert=True)
 
-@uwsgidecorators.cron(0, -1, -1, -1, -1)  # top of every hour
-def upload_storage_cleaning(num):
-    upload_path = application.config['upload_path']
-    for f in os.listdir(upload_path):
-        fp = os.path.join(upload_path, f)
-        timestamp = datetime.datetime.utcfromtimestamp(int(os.stat(fp).st_mtime))
-        if timestamp < (datetime.datetime.utcnow() - datetime.timedelta(hours=1)):
-            log.debug('upload %s was last modified %s' % (fp, str(timestamp)))
-            os.remove(fp)
 
-if not args.ssl_cert:
-    log.warning('SSL certificate not specified, Scitran Central functionality disabled')
-elif not args.api_uri:
-    log.warning('api_uri not configured. scitran central functionality disabled.')
-elif not args.site_name:
-    log.warning('site_name not configured. scitran central functionality disabled.')
-elif args.site_id == 'local':
-    log.warning('site_id is local. scitran central functionality disabled.')
-elif not args.central_uri:
-    log.warning('central_uri not configured. scitran central functionality disabled.')
+if __name__ == '__main__':
+    api.app.debug = True # send stack trace for uncaught exceptions to client
+    paste.httpserver.serve(api.app, host=args.host, port=args.port, ssl_pem=args.ssl_cert)
 else:
-    fail_count = 0
+    application = api.app # needed for uwsgi
 
-    @uwsgidecorators.timer(60)
-    def centralclient_timer(signum):
-        global fail_count
-        if not centralclient.update(application.db, args.api_uri, args.site_name, args.site_id, args.ssl_cert, args.central_uri):
-            fail_count += 1
-        else:
-            fail_count = 0
+    import datetime
+    import uwsgidecorators
 
-        if fail_count == 3:
-            log.debug('scitran central unreachable, purging all remotes info')
-            centralclient.clean_remotes(application.db, args.site_id)
+    @uwsgidecorators.cron(0, -1, -1, -1, -1)  # top of every hour
+    def upload_storage_cleaning(num):
+        upload_path = application.config['upload_path']
+        for f in os.listdir(upload_path):
+            fp = os.path.join(upload_path, f)
+            timestamp = datetime.datetime.utcfromtimestamp(int(os.stat(fp).st_mtime))
+            if timestamp < (datetime.datetime.utcnow() - datetime.timedelta(hours=1)):
+                log.debug('upload %s was last modified %s' % (fp, str(timestamp)))
+                os.remove(fp)
+
+    if centralclient_enabled:
+        fail_count = 0
+        @uwsgidecorators.timer(60)
+        def centralclient_timer(signum):
+            global fail_count
+            if not centralclient.update(application.db, args.api_uri, args.site_name, args.site_id, args.ssl_cert, args.central_uri):
+                fail_count += 1
+            else:
+                fail_count = 0
+            if fail_count == 3:
+                log.debug('scitran central unreachable, purging all remotes info')
+                centralclient.clean_remotes(application.db, args.site_id)

--- a/api.wsgi
+++ b/api.wsgi
@@ -28,6 +28,7 @@ ap.add_argument('--demo', help='enable automatic user creation', action='store_t
 ap.add_argument('--insecure', help='allow user info as urlencoded param', action='store_true', default=False)
 ap.add_argument('--central_uri', help='scitran central api', default='https://sdmc.scitran.io/api')
 ap.add_argument('--log_level', help='log level [info]', default='info')
+ap.add_argument('--secret', help='Shared secret', required=True)
 args = ap.parse_args()
 
 # HACK to allow setting the --site_name in the same way as api.py
@@ -42,6 +43,8 @@ log = logging.getLogger('scitran')
 # configure uwsgi application
 application = api.app
 application.config = vars(args)
+
+application.secret = args.secret
 
 if not os.path.exists(application.config['data_path']):
     os.makedirs(application.config['data_path'])

--- a/base.py
+++ b/base.py
@@ -54,7 +54,7 @@ class RequestHandler(webapp2.RequestHandler):
 
         # Drone shared secret authentication
         elif drone_secret is not None and self.request.user_agent.startswith('SciTran Drone '):
-            if drone_secret != self.app.config['secret']:
+            if drone_secret != self.app.config['drone_secret']:
                 self.abort(401, 'invalid drone secret')
             log.info('drone ' + self.request.user_agent.replace('SciTran Drone ', '') + ' request accepted')
             drone_request = True

--- a/base.py
+++ b/base.py
@@ -55,7 +55,7 @@ class RequestHandler(webapp2.RequestHandler):
 
         # Drone shared secret authentication
         elif drone_auth != None and self.request.user_agent.startswith('SciTran Drone '):
-            if drone_auth == "change-me":
+            if drone_auth == self.app.secret:
                 log.info('Drone ' + self.request.user_agent.replace('SciTran Drone ', '') + ' request accepted')
                 self.drone_request = True
                 self.public_request = False

--- a/base.py
+++ b/base.py
@@ -25,7 +25,11 @@ class RequestHandler(webapp2.RequestHandler):
         self.source_site = None
         self.drone_request = False
         identity = {}
+
         access_token = self.request.headers.get('Authorization', None)
+        drone_auth = self.request.headers.get('X-SciTran-Auth', None)
+
+        # User (oAuth) authentication
         if access_token and self.app.config['oauth2_id_endpoint']:
             token_request_time = datetime.datetime.now()
             cached_token = self.app.db.authtokens.find_one({'_id': access_token})
@@ -44,24 +48,33 @@ class RequestHandler(webapp2.RequestHandler):
                 else:
                     headers = {'WWW-Authenticate': 'Bearer realm="%s", error="invalid_token", error_description="Invalid OAuth2 token."' % self.app.config['site_id']}
                     self.abort(401, 'invalid oauth2 token', headers=headers)
+
+        # 'Debug' (insecure) setting: allow request to act as requested user
         elif self.debug and self.request.get('user'):
             self.uid = self.request.get('user')
-        elif self.request.user_agent.startswith('SciTran'):
-            if self.request.environ['SSL_CLIENT_VERIFY'] != 'SUCCESS':
-                self.abort(401, 'no valid SSL client certificate')
-            if self.request.user_agent.startswith('SciTran Instance'):
+
+        # Drone shared secret authentication
+        elif drone_auth != None and self.request.user_agent.startswith('SciTran Drone '):
+            if drone_auth == "change-me":
+                log.info('Drone ' + self.request.user_agent.replace('SciTran Drone ', '') + ' request accepted')
+                self.drone_request = True
+                self.public_request = False
+            else:
+                self.abort(401, 'invalid shared secret')
+
+        # Cross-site authentication
+        elif self.request.user_agent.startswith('SciTran Instance'):
+            if self.request.environ['SSL_CLIENT_VERIFY'] == 'SUCCESS':
                 self.uid = self.request.headers.get('X-User')
                 self.source_site = self.request.headers.get('X-Site')
                 remote_instance = self.request.user_agent.replace('SciTran Instance', '').strip()
                 if not self.app.db.sites.find_one({'_id': remote_instance}):
                     self.abort(402, remote_instance + ' is not an authorized remote instance')
             else:
-                drone_type, drone_id = self.request.user_agent.replace('SciTran', '').strip().split()
-                if not self.app.db.drones.find_one({'_id': drone_id}):
-                    self.abort(402, drone_id + ' is not an authorized drone')
-                self.drone_request = True
+                self.abort(401, 'no valid SSL client certificate')
+
         self.public_request = not bool(self.uid)
-        log.debug('public request: %s' % str(self.public_request))
+
         if self.drone_request and not self.source_site:  # engine request
             self.public_request = False
             self.superuser_request = True
@@ -84,6 +97,8 @@ class RequestHandler(webapp2.RequestHandler):
                 else:
                     self.abort(403, 'user ' + self.uid + ' does not exist')
             self.superuser_request = user.get('root') and user.get('wheel')
+
+        log.debug('public request: %s' % str(self.public_request))
 
     def dispatch(self):
         """dispatching and request forwarding"""

--- a/core.py
+++ b/core.py
@@ -2,6 +2,7 @@
 
 import logging
 log = logging.getLogger('scitran.api')
+logging.getLogger('MARKDOWN').setLevel(logging.WARNING) # silence Markdown library logging
 
 import os
 import re


### PR DESCRIPTION
From our notes regarding placeholder device authentication:

* Eliminating the drone port, rootCA keys, and drone keys.
* Automated authorization will be via a single shared secret stored in config.toml.
* Automated calls must set their user agent header to 'SciTran Drone NAME', where NAME can be anything (possibly ‘reaper’ or ‘engine’).
* Automated calls must send the shared secret in the X-SciTran-Auth header.
* Drone listing in the database will be completely ignored and have no effect.
* All drones will operate at the same permission level and have the same capabilities.

This adds the ability to authenticate with a shared secret via the above spec.

Does not use constant-time string compare and is thus vulnerable to [timing attacks](https://en.wikipedia.org/wiki/Timing_attack).

Requires scitran/scitran#40.