### PR TITLE
Optional NewRelic support

### DIFF
--- a/api.py
+++ b/api.py
@@ -115,6 +115,10 @@ def dispatcher(router, request, response):
         response.write(json.dumps(rv, default=bson.json_util.default))
         response.headers['Content-Type'] = 'application/json; charset=utf-8'
 
+try:
+    from newrelic import agent
+    app = agent.WSGIApplicationWrapper(webapp2.WSGIApplication(routes))
+except ImportError:
+    app = webapp2.WSGIApplication(routes)
 
-app = webapp2.WSGIApplication(routes)
 app.router.set_dispatcher(dispatcher)

--- a/api.py
+++ b/api.py
@@ -116,8 +116,8 @@ def dispatcher(router, request, response):
         response.headers['Content-Type'] = 'application/json; charset=utf-8'
 
 try:
-    from newrelic import agent
-    app = agent.WSGIApplicationWrapper(webapp2.WSGIApplication(routes))
+    import newrelic.agent
+    app = newrelic.agent.WSGIApplicationWrapper(webapp2.WSGIApplication(routes))
 except ImportError:
     app = webapp2.WSGIApplication(routes)
 

--- a/api.wsgi
+++ b/api.wsgi
@@ -1,5 +1,11 @@
 # vim: filetype=python
 
+try:
+    import newrelic.agent
+    newrelic.agent.initialize('../../newrelic.ini')
+except ImportError:
+    pass
+
 import logging
 logging.basicConfig(
         format='%(asctime)s %(name)16.16s:%(levelname)4.4s %(message)s',

--- a/api.wsgi
+++ b/api.wsgi
@@ -1,11 +1,5 @@
 # vim: filetype=python
 
-try:
-    import newrelic.agent
-    newrelic.agent.initialize('../../newrelic.ini')
-except ImportError:
-    pass
-
 import logging
 logging.basicConfig(
         format='%(asctime)s %(name)16.16s:%(levelname)4.4s %(message)s',
@@ -14,6 +8,15 @@ logging.basicConfig(
         )
 log = logging.getLogger('scitran.api')
 logging.getLogger('scitran.data').setLevel(logging.WARNING) # silence scitran.data logging
+
+try:
+    import newrelic.agent
+    newrelic.agent.initialize('../../newrelic.ini')
+    log.info('New Relic detected and loaded. Monitoring enabled.')
+except ImportError:
+    log.info('New Relic not detected. Monitoring disabled.')
+except newrelic.api.exceptions.ConfigurationError:
+    log.warn('New Relic detected but configuration was not valid. Please ensure newrelic.ini is present. Monitoring disabled.')
 
 import os
 import time


### PR DESCRIPTION
New Relic is conditionally brought in based on whether it is found in import, and fails quietly if not found.
