### PR TITLE
Fix arbitrary path access

### DIFF
--- a/containers.py
+++ b/containers.py
@@ -318,7 +318,7 @@ class Container(base.RequestHandler):
                 field = form[fieldname]
                 if fieldname == 'file':
                     filestream = field.file
-                    filename = field.filename
+                    _, filename = os.path.split(field.filename)
                 elif fieldname == 'tags':
                     try:
                         tags = json.loads(field.value)
@@ -334,6 +334,8 @@ class Container(base.RequestHandler):
         elif filename is None:
             self.abort(400, 'Request must contain a filename parameter.')
         else:
+            _, filename = os.path.split(filename)
+
             if 'Content-MD5' not in self.request.headers:
                 self.abort(400, 'Request must contain a valid "Content-MD5" header.')
             try:


### PR DESCRIPTION
User input was not sanitized, so it was possible to request read or write of any file on the system. I was able to request a specific file be written on a completely separate path from the data folder.

This PR should drop any paths on a filename parameter when up/downloading.

