### PR TITLE
Expanded upon the Group's regex patterns.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -6,14 +6,14 @@
             "_id": {
                 "maxLength": 32,
                 "minLength": 2,
-                "pattern": "^[0-9a-z]{1}[0-9a-z.@_-]{0,30}[0-9a-z]{1}$",
+                "pattern": "^[0-9a-z][0-9a-z.@_-]{0,30}[0-9a-z]$",
                 "title": "ID",
                 "type": "string"
             },
             "name": {
                 "maxLength": 32,
                 "minLength": 2,
-                "pattern": "^[0-9A-Za-z]{1}[0-9A-Za-z .@_-]{0,30}[0-9A-Za-z]{1}$",
+                "pattern": "^[0-9A-Za-z][0-9A-Za-z .@_-]{0,30}[0-9A-Za-z]$",
                 "title": "Name",
                 "type": "string"
             },

--- a/schema.json
+++ b/schema.json
@@ -6,14 +6,14 @@
             "_id": {
                 "maxLength": 32,
                 "minLength": 2,
-                "pattern": "^[0-9a-z.@_-]*$",
+                "pattern": "^[0-9a-z]{1}[0-9a-z.@_-]{0,30}[0-9a-z]{1}$",
                 "title": "ID",
                 "type": "string"
             },
             "name": {
                 "maxLength": 32,
                 "minLength": 2,
-                "pattern": "^[0-9A-Za-z .@_-]*$",
+                "pattern": "^[0-9A-Za-z]{1}[0-9A-Za-z .@_-]{0,30}[0-9A-Za-z]{1}$",
                 "title": "Name",
                 "type": "string"
             },


### PR DESCRIPTION
Both `_id` and `name` now require a letter or number at the start and end, and enforce the minimum and maximum length.