### PR TITLE
Job api fixes

### DIFF
--- a/api/jobs.py
+++ b/api/jobs.py
@@ -259,11 +259,11 @@ class Job(base.RequestHandler):
         mutation['modified'] = datetime.datetime.utcnow()
 
         # Create an object with all the fields that must not have changed concurrently.
-        jobQuery =  {
+        job_query =  {
             '_id': job['_id'],
             'state': job['state'],
         }
 
-        result = self.app.db.jobs.update_one(jobQuery, {'$set': mutation})
+        result = self.app.db.jobs.update_one(job_query, {'$set': mutation})
         if result.modified_count != 1:
             self.abort(500, 'Job modification not saved')

--- a/bin/api.wsgi
+++ b/bin/api.wsgi
@@ -189,7 +189,9 @@ else:
 
     # Run job creation immediately on start, then every 30 seconds thereafter.
     # This saves sysadmin irritation waiting for the engine, or an initial job load conflicting with timed runs.
+    log.info('Loading jobs queue for initial processing. This may take some time.')
     job_creation(None)
+    log.info('Loading jobs queue complete.')
 
     @uwsgidecorators.timer(30)
     def job_creation_timer(signum):

--- a/bin/api.wsgi
+++ b/bin/api.wsgi
@@ -141,7 +141,6 @@ else:
                 log.warning('scitran central unreachable, purging all remotes info')
                 centralclient.clean_remotes(application.db, args.site_id)
 
-    @uwsgidecorators.timer(30)
     def job_creation(signum):
         for c_type in ['projects', 'collections', 'sessions', 'acquisitions']:
             for c in application.db[c_type].find({'files.dirty': True}, ['files']):
@@ -186,3 +185,12 @@ else:
                 log.info('respawned job %s as %s (attempt %d)' % (j['_id'], job_id, j['attempt']+1))
             else:
                 log.info('permanently failed job %s (after %d attempts)' % (j['_id'], j['attempt']))
+
+
+    # Run job creation immediately on start, then every 30 seconds thereafter.
+    # This saves sysadmin irritation waiting for the engine, or an initial job load conflicting with timed runs.
+    job_creation(None)
+
+    @uwsgidecorators.timer(30)
+    def job_creation_timer(signum):
+        job_creation(signum)


### PR DESCRIPTION
Some small fixes:

* In `spawn_jobs`:
  * do not attempt to enqueue non-dicom data
  * correct parameter type passed to `queue_job`
* In `queue_job`:
  * Correct some docs
  * Correct a duplicate / erroneous job map entry
* In `Job.put`:
  * Correct query parameter
  * Check query result & inform client
* In `api.wsgi`:
  * Process job creation queue (`job_creation`) on launch before setting cron timer
  * Easier to debug, prevents any initial rush
