### PR TITLE
Correct abandoned jobs query

### DIFF
--- a/bin/api.wsgi
+++ b/bin/api.wsgi
@@ -171,7 +171,7 @@ else:
             j = application.db.jobs.find_one_and_update(
                 {
                     'state': 'running',
-                    'heartbeat': {'$lt': datetime.datetime.utcnow() - datetime.timedelta(seconds=100)},
+                    'modified': {'$lt': datetime.datetime.utcnow() - datetime.timedelta(seconds=100)},
                 },
                 {
                     '$set': {


### PR DESCRIPTION
The dead-jobs query was using an invalid key.
Because of this, abandoned jobs would never be reclaimed.