### PR TITLE
Generate job information on-the-fly

### DIFF
--- a/api/jobs.py
+++ b/api/jobs.py
@@ -248,7 +248,7 @@ class Jobs(base.RequestHandler):
             return_document=pymongo.collection.ReturnDocument.AFTER
         )
 
-        if result == None:
+        if result is None:
             self.abort(400, 'No jobs to process')
 
         # Second, update document to store formula request.
@@ -262,7 +262,7 @@ class Jobs(base.RequestHandler):
             return_document=pymongo.collection.ReturnDocument.AFTER
         )
 
-        if result == None:
+        if result is None:
             self.abort(500, 'Marked job as running but could not generate and save formula')
 
         return result


### PR DESCRIPTION
Currently a blob of JSON is saved into a job struct when the job is enqueued. There's no particular reason to do this, since it effectively serializes logic into the database before it's used.

This PR:

1. Moves non-formula keys required to generate a formula into an `intent` object
1. Adds a `generate_formula` which takes an intent
1. Upgrades `/next` to save & return the formula at the moment of launch.

