### PR TITLE
Tweak bash scripts

### DIFF
--- a/test/bootstrap_test_db.sh
+++ b/test/bootstrap_test_db.sh
@@ -1,4 +1,5 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -e
 
 if [ -z "$1" ]
   then
@@ -6,4 +7,10 @@ if [ -z "$1" ]
     exit 1
 fi
 
-../../../live.sh cmd PYTHONPATH=code/api:code/data code/api/bin/bootstrap.py users -f mongodb://localhost:9001/scitran code/api/test/test_bootstrap.json $1
+(
+	# Set cwd
+	unset CDPATH
+	cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+	../../../live.sh cmd PYTHONPATH=code/api:code/data code/api/bin/bootstrap.py users -f mongodb://localhost:9001/scitran code/api/test/test_bootstrap.json $1
+)

--- a/test/runtests.sh
+++ b/test/runtests.sh
@@ -1,3 +1,10 @@
-#!/bin/sh
+#!/usr/bin/env bash
+set -e
 
-../../../live.sh cmd PYTHONPATH=code/api:code/data nosetests -vv --exe --collect-only code/api/test/$1
+(
+	# Set cwd
+	unset CDPATH
+	cd "$( dirname "${BASH_SOURCE[0]}" )"
+
+	../../../live.sh cmd PYTHONPATH=code/api:code/data nosetests -vv --exe --collect-only code/api/test/$1
+)


### PR DESCRIPTION
A few changes:

* Use a compatible interpreter reference. Among other things, `sh` is symlinked to `bash` on OSX, which generally leads to irritation on other platforms.
* Always run relative to script path.
* Set -e mode: not very necessary ATM, but causes a script to exit on error (rather than blindly continue). 