### PR TITLE
Allow for custom newrelic.ini path

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -129,10 +129,6 @@ def dispatcher(router, request, response):
         response.headers['Content-Type'] = 'application/json; charset=utf-8'
 
 
-try:
-    import newrelic.agent
-    app = newrelic.agent.WSGIApplicationWrapper(webapp2.WSGIApplication(routes))
-except ImportError:
-    app = webapp2.WSGIApplication(routes)
+app = webapp2.WSGIApplication(routes)
 
 app.router.set_dispatcher(dispatcher)


### PR DESCRIPTION
This consolidates all new relic code into one place and removes the hardcoded path to the ini file.