### PR TITLE
fix uploads of small files

### DIFF
--- a/api/files.py
+++ b/api/files.py
@@ -34,8 +34,6 @@ def getHashingFieldStorage(upload_dir, hash_alg):
     class HashingFieldStorage(cgi.FieldStorage):
         bufsize = 2**20
         def make_file(self, binary=None):
-            if not self.filename:
-                return self.file
             self.open_file = HashingFile(os.path.join(upload_dir, os.path.basename(self.filename)), hash_alg)
             return self.open_file
 
@@ -43,8 +41,11 @@ def getHashingFieldStorage(upload_dir, hash_alg):
         # _FieldStorage__file is the private variable __file of the same class
         def _FieldStorage__write(self, line):
             if self._FieldStorage__file is not None:
-                self.file = self.make_file('')
-                self.file.write(self._FieldStorage__file.getvalue())
+                # use the make_file method only if the form includes a filename
+                # e.g. do not create a file and a hash for the form metadata.
+                if self.filename:
+                    self.file = self.make_file('')
+                    self.file.write(self._FieldStorage__file.getvalue())
                 self._FieldStorage__file = None
             self.file.write(line)
 

--- a/api/files.py
+++ b/api/files.py
@@ -34,8 +34,19 @@ def getHashingFieldStorage(upload_dir, hash_alg):
     class HashingFieldStorage(cgi.FieldStorage):
         bufsize = 2**20
         def make_file(self, binary=None):
+            if not self.filename:
+                return self.file
             self.open_file = HashingFile(os.path.join(upload_dir, os.path.basename(self.filename)), hash_alg)
             return self.open_file
+
+        # override private method __write of superclass FieldStorage
+        # _FieldStorage__file is the private variable __file of the same class
+        def _FieldStorage__write(self, line):
+            if self._FieldStorage__file is not None:
+                self.file = self.make_file('')
+                self.file.write(self._FieldStorage__file.getvalue())
+                self._FieldStorage__file = None
+            self.file.write(line)
 
         def get_hash(self):
             return self.open_file.get_hash()


### PR DESCRIPTION
cgi.FieldStorage by default doesn't use make_file.
Only if the file is bigger than 1000 bytes the method is called.
Overriding the private method __write allows to always call make_file
independently of file size.

closes #88 

@josschne please take a look to see if this is the correct way and if there are less hacky ways of fixing this.
you can check the code of the original __write method here: https://hg.python.org/cpython/file/2.7/Lib/cgi.py#l672