### PR TITLE
Add simple job stats query

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -71,6 +71,7 @@ routes = [
     webapp2_extras.routes.PathPrefixRoute(r'/api/jobs', [
         webapp2.Route(r'/next',             jobs.Jobs, handler_method='next', methods=['GET']),
         webapp2.Route(r'/count',            jobs.Jobs, handler_method='count', methods=['GET']),
+        webapp2.Route(r'/stats',            jobs.Jobs, handler_method='stats', methods=['GET']),
         webapp2.Route(r'/addTestJob',       jobs.Jobs, handler_method='addTestJob', methods=['GET']),
         webapp2.Route(r'/reap',             jobs.Jobs, handler_method='reap_stale', methods=['POST']),
         webapp2.Route(r'/<:[^/]+>',         jobs.Job,  name='job'),

--- a/api/jobs.py
+++ b/api/jobs.py
@@ -217,6 +217,20 @@ class Jobs(base.RequestHandler):
 
         return config.db.jobs.count()
 
+    def stats(self):
+        if not self.superuser_request:
+            self.abort(403, 'Request requires superuser')
+        result = config.db.jobs.aggregate([{"$group": {"_id": "$state", "count": {"$sum": 1}}}])
+
+        # Map mongo result to a useful object
+        states = {}
+        for r in result:
+            key = r['_id']
+            val = r['count']
+            states[key] = val
+
+        return states
+
     def next(self):
         """
         Atomically change a 'pending' job to 'running' and returns it. Updates timestamp.

--- a/api/jobs.py
+++ b/api/jobs.py
@@ -224,6 +224,11 @@ class Jobs(base.RequestHandler):
 
         # Map mongo result to a useful object
         states = {}
+
+        # Don't randomly omit keys that are zero
+        for s in JOB_STATES:
+            states[s] = 0
+
         for r in result:
             key = r['_id']
             val = r['count']


### PR DESCRIPTION
This adds something I've been doing manually for awhile, so may as well make it an endpoint.

Notably, this modifies a mongo aggregate result, which by default looks like this:

```json
[
    {
        "_id": "pending", 
        "count": 37
    }
]
````

Which makes for infuriating parsing, so let's clean that up:

```json
{
    "complete": 37, 
    "failed": 0, 
    "pending": 35, 
    "running": 1
}
```