### PR TITLE
disallow key updates on container sublist

### DIFF
--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -138,10 +138,7 @@ class ListHandler(base.RequestHandler):
             result = keycheck(mongo_validator(permchecker(storage.exec_op)))('PUT', _id=_id, query_params=kwargs, payload=payload)
         except APIStorageException as e:
             self.abort(400, e.message)
-        if result.modified_count == 1:
-            return {'modified':result.modified_count}
-        else:
-            self.abort(404, 'Element not updated in list {} of container {} {}'.format(storage.list_name, storage.cont_name, _id))
+        return {'modified':result.modified_count}
 
     def delete(self, cont_name, list_name, **kwargs):
         _id = kwargs.pop('cid')

--- a/api/validators.py
+++ b/api/validators.py
@@ -137,22 +137,12 @@ def key_check(handler, schema_file):
             else:
                 _check_query_params(schema.get('key_fields'), query_params)
                 if method == 'PUT' and schema.get('key_fields'):
-                    exclude_params = _put_exclude_params(schema['key_fields'], query_params, payload)
+                    for k in schema['key_fields']:
+                        if payload.get(k):
+                            handler.abort(400, 'key {} not allowed in PUT payload'.format(k))
             return exec_op(method, _id=_id, query_params=query_params, payload=payload, exclude_params=exclude_params)
         return f
     return g
-
-def _put_exclude_params(keys, query_params, payload):
-    exclude_params = None
-    _eqp = {}
-    for k in keys:
-        value_p = payload.get(k)
-        if value_p and value_p != query_params.get(k):
-            _eqp[k] = value_p
-            exclude_params = _eqp
-        else:
-            _eqp[k] = query_params.get(k)
-    return exclude_params
 
 def _post_exclude_params(keys, payload):
     return {


### PR DESCRIPTION
For PUT requests, disallow key updates on sublists like permissions, files, etc.
This closes #103 because now `result.modified_count == 0` is not a failure.
This is not true for StringListStorage. Its specific logic has been modified accordingly.