### PR TITLE
remove filetype and mimetype

### DIFF
--- a/api/core.py
+++ b/api/core.py
@@ -163,7 +163,6 @@ class Core(base.RequestHandler):
                 modified=now,
                 size=file_store.size,
                 hash=file_store.hash,
-                type=file_store.filetype,
                 tags=file_store.tags,
                 metadata=file_store.metadata
             )
@@ -236,7 +235,7 @@ class Core(base.RequestHandler):
             return [{'filename': k, 'hash': v['hash'], 'size': v['size']} for k, v in file_store.files.items()]
 
     def _merge_fileinfos(self, hard_infos, infos):
-        """it takes a dictionary of "hard_infos" (file size, hash, mimetype, filetype)
+        """it takes a dictionary of "hard_infos" (file size, hash)
         merging them with infos derived from a list of infos on the same or on other files
         """
         for info in infos:

--- a/api/files.py
+++ b/api/files.py
@@ -87,8 +87,6 @@ class FileStore(object):
             self._save_body_file(dest_path, filename, hash_alg)
         self.path = os.path.join(dest_path, self.filename)
         self.duration = datetime.datetime.utcnow() - start_time
-        self.mimetype = util.guess_mimetype(self.filename)
-        self.filetype = util.guess_filetype(self.filename, self.mimetype)
         # the hash format is:
         # <version>-<hashing algorithm>-<actual hash>
         # version will track changes on hash related methods like for example how we check for identical files.
@@ -154,11 +152,8 @@ class MultiFileStore(object):
         for field in form:
             if form[field].filename:
                 filename = os.path.basename(form[field].filename)
-                mimetype = util.guess_mimetype(filename)
                 self.files[filename] = {
                     'hash': util.format_hash(hash_alg, form[field].file.get_hash()),
                     'size': os.path.getsize(os.path.join(dest_path, filename)),
-                    'mimetype': mimetype,
-                    'filetype': util.guess_filetype(filename, mimetype),
                     'path': os.path.join(dest_path, filename)
                 }

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -339,7 +339,7 @@ class FileListHandler(ListHandler):
                 self.response.app_iter = open(filepath, 'rb')
                 self.response.headers['Content-Length'] = str(fileinfo['size']) # must be set after setting app_iter
                 if self.is_true('view'):
-                    self.response.headers['Content-Type'] = str(util.guess_mimetype(fileinfo.get('name'))) or 'application/octet-stream'
+                    self.response.headers['Content-Type'] = str(util.guess_mimetype(fileinfo.get('name')))
                 else:
                     self.response.headers['Content-Type'] = 'application/octet-stream'
                     self.response.headers['Content-Disposition'] = 'attachment; filename="' + filename + '"'

--- a/api/handlers/listhandler.py
+++ b/api/handlers/listhandler.py
@@ -339,7 +339,7 @@ class FileListHandler(ListHandler):
                 self.response.app_iter = open(filepath, 'rb')
                 self.response.headers['Content-Length'] = str(fileinfo['size']) # must be set after setting app_iter
                 if self.is_true('view'):
-                    self.response.headers['Content-Type'] = str(fileinfo.get('mimetype', 'application/octet-stream'))
+                    self.response.headers['Content-Type'] = str(util.guess_mimetype(fileinfo.get('name'))) or 'application/octet-stream'
                 else:
                     self.response.headers['Content-Type'] = 'application/octet-stream'
                     self.response.headers['Content-Disposition'] = 'attachment; filename="' + filename + '"'
@@ -364,7 +364,6 @@ class FileListHandler(ListHandler):
                 'name': file_store.filename,
                 'size': file_store.size,
                 'hash': file_store.hash,
-                'type': file_store.filetype,
                 'created': file_datetime,
                 'modified': file_datetime,
             }

--- a/api/util.py
+++ b/api/util.py
@@ -79,19 +79,6 @@ def guess_mimetype(filepath):
     return mime or 'application/octet-stream'
 
 
-def guess_filetype(filepath, mimetype):
-    """Guess file type based on filename and MIME type."""
-    type_, subtype = mimetype.split('/')
-    if filepath.endswith('.nii') or filepath.endswith('.nii.gz'):
-        return 'nifti'
-    elif filepath.endswith('_montage.zip'):
-        return 'montage'
-    elif type_ == 'text' and subtype == 'plain':
-        return 'text'
-    else:
-        return subtype
-
-
 def path_from_hash(hash_):
     """
     create a filepath from a hash

--- a/bin/bootstrap.py
+++ b/bin/bootstrap.py
@@ -109,6 +109,7 @@ def data(args):
             'name': filename,
             'size': size,
             'hash': computed_hash,
+            'type': 'dicom', # we are only bootstrapping dicoms at the moment
             'created': created,
             'modified': modified
         }


### PR DESCRIPTION
closes #137 

filetype and mimetype are obsolete fields in the DB and need to be removed.
The mimetype will be computed for each file at runtime when needed (eg on downloads).

CC @kofalt @gsfr 