### PR TITLE
Add some more job stats

### DIFF
--- a/api/jobs.py
+++ b/api/jobs.py
@@ -253,7 +253,7 @@ class Jobs(base.RequestHandler):
             by_tag.append({'tags': r['_id'], 'count': r['count']})
 
         # Count jobs that will not be retried
-        permafailed = len(list(config.db.jobs.find({"attempt": {"$gte": MAX_ATTEMPTS}, "state":"failed"})))
+        permafailed = config.db.jobs.count({"attempt": {"$gte": MAX_ATTEMPTS}, "state":"failed"})
 
         return {
             'by-state': by_state,


### PR DESCRIPTION
At the request of @gsfr, added some more job stats to the stats endpoint.
Now looks like this:

```json
{
    "by-state": {
        "complete": 0, 
        "failed": 0, 
        "pending": 74, 
        "running": 0
    }, 
    "by-tag": [
        {
            "count": 37, 
            "tags": [
                "dcm_convert", 
                "converter"
            ]
        }, 
        {
            "count": 37, 
            "tags": [
                "dicom_mr_classifier", 
                "classifier"
            ]
        }
    ], 
    "permafailed": 0
}
```