### PR TITLE
Have pip update itself in virtualenv first

### DIFF
--- a/bin/install.sh
+++ b/bin/install.sh
@@ -5,5 +5,6 @@ set -e
 unset CDPATH
 cd "$( dirname "${BASH_SOURCE[0]}" )/.."
 
+pip install -U pip
 pip install -r requirements.txt
 pip install -r requirements_dev.txt


### PR DESCRIPTION
On macOS El Capitan, the virtualenv created uses an older version of pip which must compile the cryptography wheel. This fails per pyca/cryptography#2350. Having the virtualenv pip update itself before running resolves this issue which prevents ./bin/run.sh from completing "Installing Python requirements" on macOS 10.11.
