### PR TITLE
Help wanted: attempt to implement an abstract container route

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -1,24 +1,24 @@
 import webapp2
 import webapp2_extras.routes
 
-from .download                      import Download
+from .download                          import Download
 from .handlers.abstractcontainerhandler import AbstractContainerHandler
-from .handlers.collectionshandler   import CollectionsHandler
-from .handlers.confighandler        import Config, Version
-from .handlers.containerhandler     import ContainerHandler
-from .handlers.dataexplorerhandler  import DataExplorerHandler
-from .handlers.devicehandler        import DeviceHandler
-from .handlers.grouphandler         import GroupHandler
-from .handlers.listhandler          import FileListHandler, NotesListHandler, PermissionsListHandler, TagsListHandler
-from .handlers.refererhandler       import AnalysesHandler
-from .handlers.reporthandler        import ReportHandler
-from .handlers.resolvehandler       import ResolveHandler
-from .handlers.roothandler          import RootHandler
-from .handlers.schemahandler        import SchemaHandler
-from .handlers.userhandler          import UserHandler
-from .jobs.handlers                 import BatchHandler, JobsHandler, JobHandler, GearsHandler, GearHandler, RulesHandler, RuleHandler
-from .upload                        import Upload
-from .web.base                      import RequestHandler
+from .handlers.collectionshandler       import CollectionsHandler
+from .handlers.confighandler            import Config, Version
+from .handlers.containerhandler         import ContainerHandler
+from .handlers.dataexplorerhandler      import DataExplorerHandler
+from .handlers.devicehandler            import DeviceHandler
+from .handlers.grouphandler             import GroupHandler
+from .handlers.listhandler              import FileListHandler, NotesListHandler, PermissionsListHandler, TagsListHandler
+from .handlers.refererhandler           import AnalysesHandler
+from .handlers.reporthandler            import ReportHandler
+from .handlers.resolvehandler           import ResolveHandler
+from .handlers.roothandler              import RootHandler
+from .handlers.schemahandler            import SchemaHandler
+from .handlers.userhandler              import UserHandler
+from .jobs.handlers                     import BatchHandler, JobsHandler, JobHandler, GearsHandler, GearHandler, RulesHandler, RuleHandler
+from .upload                            import Upload
+from .web.base                          import RequestHandler
 from . import config
 
 
@@ -183,9 +183,10 @@ endpoints = [
         route('/<cid:site>/rules',              RulesHandler,          m=['GET', 'POST']),
         route('/<cid:site>/rules/<rid:{cid}>',  RuleHandler,           m=['GET', 'PUT', 'DELETE']),
 
+
         # Abstract container
 
-        route('/container/<cid:{fname}><extra:.*>', AbstractContainerHandler, h='handle'),
+        route('/containers/<cid:{fname}><extra:.*>', AbstractContainerHandler, h='handle'),
 
 
         # Groups

--- a/api/api.py
+++ b/api/api.py
@@ -2,6 +2,7 @@ import webapp2
 import webapp2_extras.routes
 
 from .download                      import Download
+from .handlers.abstractcontainerhandler import AbstractContainerHandler
 from .handlers.collectionshandler   import CollectionsHandler
 from .handlers.confighandler        import Config, Version
 from .handlers.containerhandler     import ContainerHandler
@@ -181,6 +182,10 @@ endpoints = [
 
         route('/<cid:site>/rules',              RulesHandler,          m=['GET', 'POST']),
         route('/<cid:site>/rules/<rid:{cid}>',  RuleHandler,           m=['GET', 'PUT', 'DELETE']),
+
+        # Abstract container
+
+        route('/container/<cid:{fname}><extra:.*>', AbstractContainerHandler, h='handle'),
 
 
         # Groups

--- a/api/handlers/abstractcontainerhandler.py
+++ b/api/handlers/abstractcontainerhandler.py
@@ -15,7 +15,9 @@ CONTAINER_SEARCH_JS = r"""
         "groups": db.getCollection("groups").findOne({"_id" : _id}, {"_id": 1}),
         "projects": db.getCollection("projects").findOne({"_id" : _id}, {"_id": 1}),
         "sessions": db.getCollection("sessions").findOne({"_id" : _id}, {"_id": 1}),
-        "acquisitions": db.getCollection("acquisitions").findOne({"_id" : _id}, {"_id": 1})
+        "acquisitions": db.getCollection("acquisitions").findOne({"_id" : _id}, {"_id": 1}),
+        "analyses": db.getCollection("analyses").findOne({"_id" : _id}, {"_id": 1}),
+        "collections": db.getCollection("collections").findOne({"_id" : _id}, {"_id": 1})
     }
 })("%s");
 """

--- a/api/handlers/abstractcontainerhandler.py
+++ b/api/handlers/abstractcontainerhandler.py
@@ -1,95 +1,64 @@
-from webob import exc
+from webapp2 import Request
 
-from ..web import base
 from .. import config
+from ..web import base
+from ..web.errors import APINotFoundException
+
+
+# Efficiently search in multiple collections
+CONTAINER_SEARCH_JS = r"""
+(function searchContainer(_id) {
+    if (/^[a-f\d]{24}$/i.test(_id)) {
+        _id = ObjectId(_id);
+    }
+    return {
+        "groups": db.getCollection("groups").findOne({"_id" : _id}, {"_id": 1}),
+        "projects": db.getCollection("projects").findOne({"_id" : _id}, {"_id": 1}),
+        "sessions": db.getCollection("sessions").findOne({"_id" : _id}, {"_id": 1}),
+        "acquisitions": db.getCollection("acquisitions").findOne({"_id" : _id}, {"_id": 1})
+    }
+})("%s");
+"""
+
 
 class AbstractContainerHandler(base.RequestHandler):
     """
     Asbtract handler that removes the need to know a container's noun before performing an action.
     """
 
+    # pylint: disable=unused-argument
     def handle(self, cid, extra):
         """
-        Redirect a request from /containers/x/... to its proper destination.
+        Dispatch a request from /containers/x/... to its proper destination.
         For example:
             /containers/x/files --> x is a project ID --> /projects/x/files
         """
 
-        # Efficiently check many databases -.-
-        jsFunc = """
-        function searchContainer(x) {
-            return {
-                'groups': db.getCollection('groups').findOne({"_id" : x}, {"_id": 1}),
-                'projects': db.getCollection('projects').findOne({"_id" : ObjectId(x)}, {"_id": 1}),
-                'sessions': db.getCollection('sessions').findOne({"_id" : ObjectId(x)}, {"_id": 1}),
-                'acquisitions': db.getCollection('acquisitions').findOne({"_id" : ObjectId(x)}, {"_id": 1})
-            }
-        };
-        """
-
         # Run command; check result
-        command = config.db.command('eval', jsFunc + ' searchContainer("' + cid + '");')
+        command = config.db.command('eval', CONTAINER_SEARCH_JS % cid)
         result = command.get('retval')
 
         if command.get('ok') != 1.0 or result is None:
             self.abort(500, 'Error running db command')
 
         # Find which container type was found, if any
-        ctype = None
+        cont_name = None
         for key in result.keys():
             if result[key] is not None:
-                ctype = key; break
+                cont_name = key
+                break
         else:
-            self.abort(404, 'No container ' + cid + ' found')
+            raise APINotFoundException('No container ' + cid + ' found')
 
-        # Construct resultant URL
-        destination = '/api/' + ctype + '/' + cid + extra
+        # Create new request instance using destination URI (eg. replace containers with cont_name)
+        destination_environ = self.request.environ
+        for key in 'PATH_INFO', 'REQUEST_URI':
+            destination_environ[key] = destination_environ[key].replace('containers', cont_name, 1)
+        destination_request = Request(destination_environ)
 
+        # Apply SciTranRequest attrs
+        destination_request.id = self.request.id
+        destination_request.logger = self.request.logger
 
-        url = self.request.path_qs
-
-        print
-        print
-        print url
-        print destination
-
-        # print self.request.environ
-
-        for route in self.app.router.match_routes:
-            try:
-                match = route.match(self.request)
-
-                if match:
-
-                    print route
-                    print 'MATCHED'
-
-                    import pprint
-                    pprint.pprint(vars(route))
-
-                    # route.handler_method(*args, **kwargs)
-
-                    break
-
-            except exc.HTTPMethodNotAllowed:
-                pass
-        else:
-            print 'NOT MATCHED'
-
-
-
-        # Technically, request.path should not have param args
-        # self.request.path = destination
-        # self.request.path_qs = destination
-
-        # thing = self.app.router.dispatch(self.request, self.response)
-
-
-        print 'FINISHED'
-
-        # print thing
-
-        # return super(base.RequestHandler, self).dispatch()
-
-        # This needs to just serve a handler, rather than redirect
-        # self.redirect(destination, permanent=False)
+        # Dispatch the destination request
+        self.app.router.dispatch(destination_request, self.response)

--- a/api/handlers/abstractcontainerhandler.py
+++ b/api/handlers/abstractcontainerhandler.py
@@ -1,0 +1,95 @@
+from webob import exc
+
+from ..web import base
+from .. import config
+
+class AbstractContainerHandler(base.RequestHandler):
+    """
+    Asbtract handler that removes the need to know a container's noun before performing an action.
+    """
+
+    def handle(self, cid, extra):
+        """
+        Redirect a request from /containers/x/... to its proper destination.
+        For example:
+            /containers/x/files --> x is a project ID --> /projects/x/files
+        """
+
+        # Efficiently check many databases -.-
+        jsFunc = """
+        function searchContainer(x) {
+            return {
+                'groups': db.getCollection('groups').findOne({"_id" : x}, {"_id": 1}),
+                'projects': db.getCollection('projects').findOne({"_id" : ObjectId(x)}, {"_id": 1}),
+                'sessions': db.getCollection('sessions').findOne({"_id" : ObjectId(x)}, {"_id": 1}),
+                'acquisitions': db.getCollection('acquisitions').findOne({"_id" : ObjectId(x)}, {"_id": 1})
+            }
+        };
+        """
+
+        # Run command; check result
+        command = config.db.command('eval', jsFunc + ' searchContainer("' + cid + '");')
+        result = command.get('retval')
+
+        if command.get('ok') != 1.0 or result is None:
+            self.abort(500, 'Error running db command')
+
+        # Find which container type was found, if any
+        ctype = None
+        for key in result.keys():
+            if result[key] is not None:
+                ctype = key; break
+        else:
+            self.abort(404, 'No container ' + cid + ' found')
+
+        # Construct resultant URL
+        destination = '/api/' + ctype + '/' + cid + extra
+
+
+        url = self.request.path_qs
+
+        print
+        print
+        print url
+        print destination
+
+        # print self.request.environ
+
+        for route in self.app.router.match_routes:
+            try:
+                match = route.match(self.request)
+
+                if match:
+
+                    print route
+                    print 'MATCHED'
+
+                    import pprint
+                    pprint.pprint(vars(route))
+
+                    # route.handler_method(*args, **kwargs)
+
+                    break
+
+            except exc.HTTPMethodNotAllowed:
+                pass
+        else:
+            print 'NOT MATCHED'
+
+
+
+        # Technically, request.path should not have param args
+        # self.request.path = destination
+        # self.request.path_qs = destination
+
+        # thing = self.app.router.dispatch(self.request, self.response)
+
+
+        print 'FINISHED'
+
+        # print thing
+
+        # return super(base.RequestHandler, self).dispatch()
+
+        # This needs to just serve a handler, rather than redirect
+        # self.redirect(destination, permanent=False)

--- a/api/web/errors.py
+++ b/api/web/errors.py
@@ -59,4 +59,3 @@ class FileFormException(Exception):
 # Payload for a POST or PUT does not match input json schema
 class InputValidationException(Exception):
     pass
-

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -1331,13 +1331,16 @@ def test_container_delete_tag(data_builder, default_payload, as_root, as_admin, 
     # test that the (now) empty group can be deleted
     assert as_root.delete('/groups/' + group).ok
 
-def test_abstract_containers(data_builder, as_admin):
+def test_abstract_containers(data_builder, as_admin, file_form):
     group = data_builder.create_group()
     project = data_builder.create_project()
     session = data_builder.create_session()
     acquisition = data_builder.create_acquisition()
+    analysis = as_admin.post('/sessions/' + session + '/analyses', files=file_form(
+        'analysis.csv', meta={'label': 'no-job', 'inputs': [{'name': 'analysis.csv'}]})).json()['_id']
+    collection = data_builder.create_collection()
 
-    for cont in (acquisition, session, project, group):
+    for cont in (collection, analysis, acquisition, session, project, group):
         r = as_admin.post('/containers/' + cont + '/tags', json={'value': 'abstract1'})
         assert r.ok
 
@@ -1352,6 +1355,8 @@ def test_abstract_containers(data_builder, as_admin):
         assert r.ok
         assert r.json() == 'abstract2'
 
+    # /analyses/x does not support DELETE (yet?)
+    for cont in (collection, acquisition, session, project, group):
         r = as_admin.delete('/containers/' + cont)
         assert r.ok
 

--- a/tests/integration_tests/python/test_containers.py
+++ b/tests/integration_tests/python/test_containers.py
@@ -1331,3 +1331,29 @@ def test_container_delete_tag(data_builder, default_payload, as_root, as_admin, 
     # test that the (now) empty group can be deleted
     assert as_root.delete('/groups/' + group).ok
 
+def test_abstract_containers(data_builder, as_admin):
+    group = data_builder.create_group()
+    project = data_builder.create_project()
+    session = data_builder.create_session()
+    acquisition = data_builder.create_acquisition()
+
+    for cont in (acquisition, session, project, group):
+        r = as_admin.post('/containers/' + cont + '/tags', json={'value': 'abstract1'})
+        assert r.ok
+
+        r = as_admin.get('/containers/' + cont)
+        assert r.ok
+        assert r.json()['tags'] == ['abstract1']
+
+        r = as_admin.put('/containers/' + cont + '/tags/abstract1', json={'value': 'abstract2'})
+        assert r.ok
+
+        r = as_admin.get('/containers/' + cont + '/tags/abstract2')
+        assert r.ok
+        assert r.json() == 'abstract2'
+
+        r = as_admin.delete('/containers/' + cont)
+        assert r.ok
+
+        r = as_admin.get('/containers/' + cont)
+        assert r.status_code == 404


### PR DESCRIPTION
A big problem with exposing our functionality is that everything has a 5x multiplier: `AddAcquisitionNote`. This blocks doing some useful stuff in the SDK because the functions would be irritating and confusing.

We should provide `/container/x` routes that figure out which type of container we mean, and just serve the equivalent route. This PR is an incomplete version of doing just that!

**Solved problem:** we need an efficient way to resolve the container noun. Might be solved for free if we ever can truly homogenize containers. While the func snippet + db command approach here is a bit ugly on the code, I can confirm it is quite efficient and safe to use.

**Unsolved problem:** make webapp2 just serve a different handler, dangit. The commented-out `self.redirect` approach totally works: you can `GET api/container/x/sessions` where x is a project ID. But that won't work for non-gets, and we shouldn't redirect anyway. We should just serve.

I'm 90% sure we can take these code scraps, and either:

1. Modify the (~5) fields of the request object to reflect the "proxying"
1. Construct a new context with the same body reader?

And call a handler method. Help?