### PR TITLE
Propose batch from pre-constructed jobs

### DIFF
--- a/api/api.py
+++ b/api/api.py
@@ -157,12 +157,13 @@ endpoints = [
 
         # Batch jobs
 
-        route('/batch',                 BatchHandler,   h='get_all',    m=['GET']),
-        route('/batch',                 BatchHandler,                   m=['POST']),
+        route('/batch',                 BatchHandler,   h='get_all',        m=['GET']),
+        route('/batch',                 BatchHandler,                       m=['POST']),
         prefix('/batch', [
-            route('/<:[^/]+>',          BatchHandler,   h='get',        m=['GET']),
-            route('/<:[^/]+>/run',      BatchHandler,   h='run',        m=['POST']),
-            route('/<:[^/]+>/cancel',   BatchHandler,   h='cancel',     m=['POST']),
+            route('/jobs',              BatchHandler,   h='post_with_jobs', m=['POST']),
+            route('/<:[^/]+>',          BatchHandler,   h='get',            m=['GET']),
+            route('/<:[^/]+>/run',      BatchHandler,   h='run',            m=['POST']),
+            route('/<:[^/]+>/cancel',   BatchHandler,   h='cancel',         m=['POST']),
         ]),
 
 

--- a/api/dao/containerstorage.py
+++ b/api/dao/containerstorage.py
@@ -372,6 +372,7 @@ class AnalysisStorage(ContainerStorage):
         try:
 
             job = Queue.enqueue_job(job, origin, perm_check_uid=uid)
+            job.insert()
         except Exception as e:
             # NOTE #775 remove unusable analysis - until jobs have a 'hold' state
             self.delete_el(analysis['_id'])

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -630,6 +630,27 @@ class BatchHandler(base.RequestHandler):
         return batch_proposal
 
     @require_login
+    def post_with_jobs(self):
+        """
+        Creates a batch from preconstructed jobs
+        """
+        payload = self.request.json
+        jobs_ = payload.get('jobs', [])
+
+        batch_proposal = {
+            'proposal': {
+                'preconstructed_jobs': jobs_
+            },
+            'origin': self.origin,
+            'state': 'pending',
+            '_id': bson.ObjectId()
+        }
+        batch.insert(batch_proposal)
+        batch_proposal['preconstructed_jobs'] = batch_proposal.pop('proposal')
+
+        return batch_proposal
+
+    @require_login
     def run(self, _id):
         """
         Creates jobs from proposed inputs, returns jobs enqueued.

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -637,6 +637,16 @@ class BatchHandler(base.RequestHandler):
         payload = self.request.json
         jobs_ = payload.get('jobs', [])
 
+        uid = None
+        if not self.superuser_request:
+            uid = self.uid
+
+        for job_number, job_ in enumerate(jobs_):
+            try:
+                Queue.validate_job(job_, self.origin, create_job=False, perm_check_uid=uid)
+            except InputValidationException as e:
+                raise InputValidationException("Job {}: {}".format(job_number, str(e)))
+
         batch_proposal = {
             'proposal': {
                 'preconstructed_jobs': jobs_

--- a/api/jobs/handlers.py
+++ b/api/jobs/handlers.py
@@ -241,6 +241,8 @@ class JobsHandler(base.RequestHandler):
             uid = self.uid
 
         job = Queue.enqueue_job(payload, self.origin, perm_check_uid=uid)
+        job.insert()
+
         return { '_id': job.id_ }
 
     @require_admin
@@ -643,7 +645,7 @@ class BatchHandler(base.RequestHandler):
 
         for job_number, job_ in enumerate(jobs_):
             try:
-                Queue.validate_job(job_, self.origin, create_job=False, perm_check_uid=uid)
+                Queue.enqueue_job(job_, self.origin, perm_check_uid=uid)
             except InputValidationException as e:
                 raise InputValidationException("Job {}: {}".format(job_number, str(e)))
 

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -128,11 +128,10 @@ class Queue(object):
 
         return new_id
 
-
     @staticmethod
-    def enqueue_job(job_map, origin, perm_check_uid=None):
+    def validate_job(job_map, origin, create_job=False, perm_check_uid=None):
         """
-        Using a payload for a proposed job, creates and returns (but does not insert)
+        Using a payload for a proposed job, creates and returns(if create_job is True) (but does not insert)
         a Job object. This preperation includes:
           - confirms gear exists
           - validates config against gear manifest
@@ -251,8 +250,17 @@ class Queue(object):
 
         if gear_name not in tags:
             tags.append(gear_name)
+        if create_job:
+            job = Job(str(gear['_id']), inputs, destination=destination, tags=tags, config_=config_, now=now_flag, attempt=attempt_n, previous_job_id=previous_job_id, origin=origin, batch=batch)
+            return job
+        return True
 
-        job = Job(str(gear['_id']), inputs, destination=destination, tags=tags, config_=config_, now=now_flag, attempt=attempt_n, previous_job_id=previous_job_id, origin=origin, batch=batch)
+    @staticmethod
+    def enqueue_job(job_map, origin, perm_check_uid=None):
+        """
+        Validates, Creates, Inserts, and Returns job
+        """
+        job = Queue.validate_job(job_map, origin, create_job=True, perm_check_uid=perm_check_uid)
         job.insert()
         return job
 

--- a/api/jobs/queue.py
+++ b/api/jobs/queue.py
@@ -128,10 +128,11 @@ class Queue(object):
 
         return new_id
 
+
     @staticmethod
-    def validate_job(job_map, origin, create_job=False, perm_check_uid=None):
+    def enqueue_job(job_map, origin, perm_check_uid=None):
         """
-        Using a payload for a proposed job, creates and returns(if create_job is True) (but does not insert)
+        Using a payload for a proposed job, creates and returns (but does not insert)
         a Job object. This preperation includes:
           - confirms gear exists
           - validates config against gear manifest
@@ -250,18 +251,8 @@ class Queue(object):
 
         if gear_name not in tags:
             tags.append(gear_name)
-        if create_job:
-            job = Job(str(gear['_id']), inputs, destination=destination, tags=tags, config_=config_, now=now_flag, attempt=attempt_n, previous_job_id=previous_job_id, origin=origin, batch=batch)
-            return job
-        return True
 
-    @staticmethod
-    def enqueue_job(job_map, origin, perm_check_uid=None):
-        """
-        Validates, Creates, Inserts, and Returns job
-        """
-        job = Queue.validate_job(job_map, origin, create_job=True, perm_check_uid=perm_check_uid)
-        job.insert()
+        job = Job(str(gear['_id']), inputs, destination=destination, tags=tags, config_=config_, now=now_flag, attempt=attempt_n, previous_job_id=previous_job_id, origin=origin, batch=batch)
         return job
 
     @staticmethod

--- a/api/jobs/rules.py
+++ b/api/jobs/rules.py
@@ -246,7 +246,8 @@ def create_jobs(db, container_before, container_after, container_type):
 
     for pj in potential_jobs:
         job_map = pj['job'].map()
-        Queue.enqueue_job(job_map, origin)
+        job = Queue.enqueue_job(job_map, origin)
+        job.insert()
 
         spawned_jobs.append(pj['rule']['alg'])
 

--- a/swagger/paths/batch.yaml
+++ b/swagger/paths/batch.yaml
@@ -31,6 +31,28 @@
         # schema:
           # $ref: schemas/output/batch-insert.json
 
+/batch/job:
+  post:
+    summary: Create a batch job proposal from preconstructed jobs and insert it as 'pending'.
+    operationId: create_batch_job_from_jobs
+    tags:
+    - batch
+    parameters:
+      - name: body
+        in: body
+        description: ''
+        schema:
+          type: array
+          # Schema file does not exist
+          # $ref: schemas/input/batch-insert.json
+    responses:
+      '200':
+        description: ''
+        # Schema file does not exist
+        # schema:
+          # $ref: schemas/output/batch-insert.json
+
+
 /batch/{BatchId}:
   parameters:
     - in: path
@@ -94,5 +116,5 @@
       '200':
         description: ''
         examples:
-          response: 
+          response:
             canceled_jobs: 4

--- a/tests/integration_tests/python/test_batch.py
+++ b/tests/integration_tests/python/test_batch.py
@@ -84,6 +84,30 @@ def test_batch(data_builder, as_user, as_admin, as_root):
     assert r.ok
     analysis_batch_id = r.json()['_id']
 
+    # try to create a batch with invalid preconstructed jobs
+    r = as_admin.post('/batch/jobs', json={
+        'jobs': [
+            {
+                'gear_id': gear,
+                'inputs': {
+                    'dicom': {
+                        'type': 'acquisition',
+                        'id': acquisition,
+                        'name': 'test.zip'
+                    }
+                },
+                'config': { 'two-digit multiple of ten': 20 },
+                'destination': {
+                    'type': 'acquisition',
+                    'id': acquisition
+                },
+                'tags': [ 'test-tag' ]
+            }
+        ]
+    })
+    assert r.status_code == 400
+    assert "Job 0" in r.json().get('message')
+
     # create a batch with preconstructed jobs
     r = as_admin.post('/batch/jobs', json={
         'jobs': [


### PR DESCRIPTION
Fixes #940 
### Changes
- New Endpoint: `POST /batch/jobs` with a list of jobs, `jobs: [{...}, {...}, ...]`, in the payload
- The job maps from the payload are stored in `batch.proposal.preconstructed_jobs` in mongo
- Jobs are validated on proposal for gear manifest, inputs, config, and permissions
- On batch run, the jobs then follow the normal job cycle
### Review Checklist

- Tests were added to cover all code changes
- Documentation was added / updated
- Code and tests follow standards in CONTRIBUTING.md
